### PR TITLE
Added Simple block Structure and Creative Tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Dynamic-Crops
+
+This mod is being developed by a couple guys who know hardly anything about Java, and even less about Forge Modding. Expect serious issues until we learn how things work, alright? Thanks for the cooperation!

--- a/main/java/com/nicjames2378/DynamicCrops/GUI/UICreativeTab.java
+++ b/main/java/com/nicjames2378/DynamicCrops/GUI/UICreativeTab.java
@@ -1,0 +1,17 @@
+package com.nicjames2378.DynamicCrops.GUI;
+
+import net.minecraft.creativetab.*;
+import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+
+public class UICreativeTab extends CreativeTabs {
+	public UICreativeTab (int index, String label) {
+		super(index, label);
+	}
+	
+	@Override
+	public ItemStack getTabIconItem() {
+		return new ItemStack(Blocks.SOUL_SAND);
+	}
+}

--- a/main/java/com/nicjames2378/DynamicCrops/Main.java
+++ b/main/java/com/nicjames2378/DynamicCrops/Main.java
@@ -2,9 +2,14 @@ package com.nicjames2378.DynamicCrops;
 
 import java.lang.reflect.Method;
 
+import org.apache.logging.log4j.Logger;
+
+import com.nicjames2378.DynamicCrops.GUI.UICreativeTab;
+import com.nicjames2378.DynamicCrops.blocks.ModBlocks;
 import com.nicjames2378.DynamicCrops.proxy.CommonProxy;
 import com.nicjames2378.DynamicCrops.utils.Reference;
 
+import net.minecraft.creativetab.CreativeTabs;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.Mod.Instance;
@@ -17,17 +22,20 @@ import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 public class Main {
 
 	@Instance
-	public static Main instance;
-	
+	public static Main instance;	
 	@SidedProxy(clientSide = Reference.CLIENT_PROXY_CLASS, serverSide = Reference.COMMON_PROXY_CLASS)
-	public static CommonProxy proxy;
-	
-	private static Logger logger;
+	public static CommonProxy proxy;	
+	public static Logger logger;	
+	public static CreativeTabs modCreativeTab;
 	
 	@EventHandler
 	public static void PreInit(FMLPreInitializationEvent event) {
 		logger = event.getModLog();
 		logger.info("DynamicCrops, ready for action!");
+		
+		modCreativeTab = new UICreativeTab(CreativeTabs.getNextID(), "tabmod");
+		ModBlocks.Initialize();		
+		
 		proxy.PreInit(event);
 	}
 	

--- a/main/java/com/nicjames2378/DynamicCrops/blocks/ModBlocks.java
+++ b/main/java/com/nicjames2378/DynamicCrops/blocks/ModBlocks.java
@@ -1,0 +1,57 @@
+package com.nicjames2378.DynamicCrops.blocks;
+
+import com.nicjames2378.DynamicCrops.Main;
+import com.nicjames2378.DynamicCrops.utils.Reference;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemBlock;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.common.registry.GameRegistry;
+
+final class ModdedBlock extends Block {
+	ModdedBlock(Material material, String unlocalizedName, String registryName ) {
+		super(material);
+		setUnlocalizedName(Reference.MOD_ID + "." + unlocalizedName);
+		setRegistryName(registryName);
+		setCreativeTab(Main.modCreativeTab);
+	}
+	
+	ModdedBlock(Material material, String registryName ) {
+		super(material);
+		setUnlocalizedName(Reference.MOD_ID + "." + registryName);
+		setRegistryName(registryName);
+		setCreativeTab(Main.modCreativeTab);
+	}
+}
+
+public class ModBlocks {	
+    private static List<ModdedBlock> blockList = new ArrayList<ModdedBlock> ();
+    
+    public static void Initialize() { // Add any blocks with no special tile data here. They will be looped and generated automatically.
+    	blockList.add(new ModdedBlock(Material.ROCK, "testanium"));
+    	blockList.add(new ModdedBlock(Material.ROCK, "randomium"));
+    	blockList.add(new ModdedBlock(Material.ROCK, "noideasium"));
+    	blockList.add(new ModdedBlock(Material.ROCK, "anotherblock"));
+    	blockList.add(new ModdedBlock(Material.ROCK, "yetanotheroneium"));
+    }
+    
+    public static void RegisterBlocks(RegistryEvent.Register<Block> event) {
+    	Main.logger.info("REGISTERING BLOCKS");
+    	
+    	for (ModdedBlock mb : blockList) {
+    		event.getRegistry().register(mb);
+    	}    	
+    }
+    
+    public static void RegisterItems(RegistryEvent.Register<Item> event) {
+    	Main.logger.info("REGISTERING ITEMS");
+        for (ModdedBlock mb : blockList) {
+    		event.getRegistry().register(new ItemBlock(mb).setRegistryName(mb.getUnlocalizedName()));
+    	}
+    }
+}

--- a/main/java/com/nicjames2378/DynamicCrops/proxy/ClientProxy.java
+++ b/main/java/com/nicjames2378/DynamicCrops/proxy/ClientProxy.java
@@ -1,12 +1,19 @@
 package com.nicjames2378.DynamicCrops.proxy;
 
+import com.nicjames2378.DynamicCrops.Main;
+import com.nicjames2378.DynamicCrops.blocks.ModBlocks;
 import com.nicjames2378.DynamicCrops.utils.Reference;
 
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemBlock;
+import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 
 @Mod.EventBusSubscriber(modid=Reference.MOD_ID, value = Side.CLIENT)
@@ -25,4 +32,14 @@ public class ClientProxy extends CommonProxy {
 	public void PostInit(FMLPostInitializationEvent event) {
 		super.PostInit(event);
 	}
+		
+	@SubscribeEvent
+    public static void RegisterBlocks(RegistryEvent.Register<Block> event) {
+    	ModBlocks.RegisterBlocks(event);
+    }
+    
+	@SubscribeEvent
+    public static void RegisterItems(RegistryEvent.Register<Item> event) {
+    	ModBlocks.RegisterItems(event);
+    }
 }

--- a/main/java/com/nicjames2378/DynamicCrops/proxy/CommonProxy.java
+++ b/main/java/com/nicjames2378/DynamicCrops/proxy/CommonProxy.java
@@ -1,19 +1,26 @@
 package com.nicjames2378.DynamicCrops.proxy;
 
+import com.nicjames2378.DynamicCrops.Main;
+import com.nicjames2378.DynamicCrops.blocks.ModBlocks;
 import com.nicjames2378.DynamicCrops.utils.Reference;
 
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemBlock;
+import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 
 @Mod.EventBusSubscriber(modid=Reference.MOD_ID, value = Side.SERVER)
 
 public class CommonProxy {	
 	public void PreInit(FMLPreInitializationEvent event) {
-	
+
 	}
 	
 	public void Init(FMLInitializationEvent event) {
@@ -23,4 +30,14 @@ public class CommonProxy {
 	public void PostInit(FMLPostInitializationEvent event) {
 
 	}
+	
+    @SubscribeEvent
+    public static void registerBlocks(RegistryEvent.Register<Block> event) {
+        ModBlocks.RegisterBlocks(event);
+    }
+
+    @SubscribeEvent
+    public static void registerItems(RegistryEvent.Register<Item> event) {
+    	ModBlocks.RegisterItems(event);
+    }
 }

--- a/main/resources/assets/dynamiccrops/lang/en_us.lang
+++ b/main/resources/assets/dynamiccrops/lang/en_us.lang
@@ -1,0 +1,7 @@
+itemGroup.dynamicrops=Dynamic Crops
+
+tile.dynamiccrops.testanium.name=Testanium
+tile.dynamiccrops.randomium.name=Randomium
+tile.dynamiccrops.noideasium.name=NoIdeasium
+tile.dynamiccrops.anotherblock.name=AnotherBlockium
+tile.dynamiccrops.yetanotheroneium.name=YetAnotherOneium

--- a/main/resources/changelog.txt
+++ b/main/resources/changelog.txt
@@ -1,3 +1,8 @@
+1.0.3
++Implemented creative tab
++Implemented basic system for non-tile blocks for adding decorative blocks easier. Texturing and modeling incomplete.
++Added language file as a basic of how it works. Can be changed as needed, as long as current syntax is followed.
+
 1.0.2
 ~Implemented internal logger
 

--- a/main/resources/pack.mcmeta
+++ b/main/resources/pack.mcmeta
@@ -1,7 +1,7 @@
 {
     "pack": {
-        "description": "examplemod resources",
+        "description": "Resources used for Dynamic Crops",
         "pack_format": 3,
-        "_comment": "A pack_format of 3 should be used starting with Minecraft 1.11. All resources, including language files, should be lowercase (eg: en_us.lang). A pack_format of 2 will load your mod resources with LegacyV2Adapter, which requires language files to have uppercase letters (eg: en_US.lang)."
+        "_comment": ""
     }
 }


### PR DESCRIPTION
Implements a simple structure for adding non-tile blocks. TODO: Add model and texture system.

Also adds a creative tab for when we start adding items to the game. This should allow easier testing than using chat commands to spawn everything in.

Lastly, there is now a language file. Look at it for reference of how to name things in game.